### PR TITLE
Uncomment `retryEnvelope` Forwarder test

### DIFF
--- a/tests/BaseCCForwarder.t.sol
+++ b/tests/BaseCCForwarder.t.sol
@@ -239,6 +239,11 @@ contract BaseCCForwarderTest is BaseTest, CrossChainForwarder {
       abi.encodeWithSelector(IBaseAdapter.setupPayments.selector),
       abi.encode()
     );
+    vm.mockCall(
+      address(currentChainBridgeAdapter),
+      abi.encodeWithSelector(IBaseAdapter.forwardMessage.selector),
+      abi.encode()
+    );
     _enableBridgeAdapters(bridgeAdaptersInfo);
   }
 

--- a/tests/Forwarder.t.sol
+++ b/tests/Forwarder.t.sol
@@ -74,30 +74,30 @@ contract ForwarderTest is BaseCCForwarderTest {
     _validateForwardMessageWhenAtLeastOneAdapterWorking(extendedTx);
   }
 
-  // function testRetryEnvelope(
-  //   address destination,
-  //   address origin,
-  //   uint256 destinationChainId,
-  //   address owner,
-  //   uint256 envelopeNonce
-  // )
-  //   public
-  //   executeAsOwner(owner)
-  //   enableBridgeAdaptersForPath(destinationChainId, 5, AdapterSuccessType.ALL_SUCCESS)
-  // {
-  //   ExtendedTransaction memory extendedTx = _generateExtendedTransaction(
-  //     TestParams({
-  //       destination: destination,
-  //       origin: origin,
-  //       originChainId: block.chainid,
-  //       destinationChainId: destinationChainId,
-  //       envelopeNonce: envelopeNonce,
-  //       transactionNonce: _currentTransactionNonce
-  //     })
-  //   );
-  //   _registerEnvelope(extendedTx);
-  //   _validateRetryEnvelopeSuccessful(extendedTx);
-  // }
+  function testRetryEnvelope(
+    address destination,
+    address origin,
+    uint256 destinationChainId,
+    address owner,
+    uint256 envelopeNonce
+  )
+    public
+    executeAsOwner(owner)
+    enableBridgeAdaptersForPath(destinationChainId, 5, AdapterSuccessType.ALL_SUCCESS)
+  {
+    ExtendedTransaction memory extendedTx = _generateExtendedTransaction(
+      TestParams({
+        destination: destination,
+        origin: origin,
+        originChainId: block.chainid,
+        destinationChainId: destinationChainId,
+        envelopeNonce: envelopeNonce,
+        transactionNonce: _currentTransactionNonce
+      })
+    );
+    _registerEnvelope(extendedTx);
+    _validateRetryEnvelopeSuccessful(extendedTx);
+  }
 
   function testRetryEnvelopeWhenNoAdapters(
     address destination,


### PR DESCRIPTION
We were mocking the contract at that address but for another function, and the return value wasn't really used (it was fine for it to be empty).
To fix, we mock the function being called as well, so zkVM won't error out.