### PR TITLE
Fix `forwardMessage` mock in `Forwarder.t.sol`

### DIFF
--- a/tests/BaseCCForwarder.t.sol
+++ b/tests/BaseCCForwarder.t.sol
@@ -239,11 +239,6 @@ contract BaseCCForwarderTest is BaseTest, CrossChainForwarder {
       abi.encodeWithSelector(IBaseAdapter.setupPayments.selector),
       abi.encode()
     );
-    vm.mockCall(
-      address(currentChainBridgeAdapter),
-      abi.encodeWithSelector(IBaseAdapter.forwardMessage.selector),
-      abi.encode()
-    );
     _enableBridgeAdapters(bridgeAdaptersInfo);
   }
 

--- a/tests/Forwarder.t.sol
+++ b/tests/Forwarder.t.sol
@@ -406,6 +406,7 @@ contract ForwarderTest is BaseCCForwarderTest {
     validateTransactionNonceIncrement
     validateTransactionRegistry(extendedTx)
   {
+    _mockAdaptersForwardMessage(extendedTx.envelope.destinationChainId);
     UsedAdapter[] memory usedAdapters = _currentlyUsedAdaptersByChain[
       extendedTx.envelope.destinationChainId
     ];


### PR DESCRIPTION
Fixes regression introduced by #13, where the mock was applied indiscriminately to all enabled adapters.
This caused other tests (that weren't expecting the mock) to now fail.

`retryEnvelope` still needs this mock, so the appropriate function has been used instead, specifically in the execution of `_validateRetryEnvelopeSuccessfull`, mirroring the usage in `_testForwardMessage`.

To note that if we mirrored `_mockAdaptersForwardMessage`'s behavior in the previous mocking, this regression wouldn't have been observed, meaning that the location wasn't neccessarily incorrect, just the way we were mocking.