### PR TITLE
Ensure called address are not `tx.origin`

### DIFF
--- a/tests/adapters/HyperLaneAdapter.t.sol
+++ b/tests/adapters/HyperLaneAdapter.t.sol
@@ -21,6 +21,7 @@ contract HyperLaneAdapterTest is BaseAdapterTest {
     uint256 baseGasLimit,
     uint256 originChainId
   ) {
+    vm.assume(crossChainController != tx.origin); // zkVM doesn't support mocking tx.origin
     vm.assume(mailBox > address(65536));
     vm.assume(originForwarder > address(65536));
     vm.assume(crossChainController > address(65536));

--- a/tests/adapters/LayerZeroAdapter.t.sol
+++ b/tests/adapters/LayerZeroAdapter.t.sol
@@ -19,6 +19,7 @@ contract LayerZeroAdapterTest is BaseAdapterTest {
     uint256 baseGasLimit,
     uint256 originChainId
   ) {
+    vm.assume(crossChainController != tx.origin); // zkVM doesn't support mocking tx.origin
     vm.assume(lzEndpoint > address(65536));
     vm.assume(originForwarder > address(65536));
     vm.assume(crossChainController > address(65536));

--- a/tests/adapters/WormholeAdapter.t.sol
+++ b/tests/adapters/WormholeAdapter.t.sol
@@ -21,6 +21,7 @@ contract WormholeAdapterTest is BaseAdapterTest {
     uint256 baseGasLimit,
     uint256 originChainId
   ) {
+    vm.assume(crossChainController != tx.origin); // zkVM doesn't support mocking tx.origin
     vm.assume(crossChainController > address(65536));
     vm.assume(wormholeRelayer > address(65536));
     vm.assume(originForwarder > address(65536));

--- a/tests/adapters/ZkSyncAdapter.t.sol
+++ b/tests/adapters/ZkSyncAdapter.t.sol
@@ -21,6 +21,7 @@ contract ZkSyncAdapterTest is BaseAdapterTest {
     uint256 baseGasLimit,
     uint256 originChainId
   ) {
+    vm.assume(crossChainController != tx.origin); // zkVM doesn't support mocking tx.origin
     vm.assume(crossChainController > address(65536));
     vm.assume(mailBox > address(65536));
     vm.assume(originForwarder > address(65536));


### PR DESCRIPTION
Some fuzz tests were failing due to the `tx.origin` address being called to. This is currently not supported.